### PR TITLE
Long table names overlap in small devices mode #13

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -37,7 +37,7 @@
         padding-left: 50% !important;
         white-space: normal;
         text-align: left;
-
+        overflow:auto;
         display: block;
         -webkit-box-sizing: content-box;
            -moz-box-sizing: content-box;


### PR DESCRIPTION
Added a tag to make the box scrollable if the length limit is exceeded.